### PR TITLE
添加全量更新抽卡记录，修了特定情况下体力推送报错，抽卡记录缺失图片报错

### DIFF
--- a/ZZZeroUID/zzzerouid_gachalog/__init__.py
+++ b/ZZZeroUID/zzzerouid_gachalog/__init__.py
@@ -6,7 +6,7 @@ from gsuid_core.logger import logger
 from ..utils.uid import get_uid
 from .draw_gachalogs import draw_card
 from ..utils.hint import BIND_UID_HINT
-from .get_gachalogs import save_gachalogs
+from .get_gachalogs import save_gachalogs, get_full_gachalog
 
 sv_gacha_log = SV("zzz抽卡记录")
 sv_get_refresh_gachalog = SV("zzz刷新抽卡记录")
@@ -36,4 +36,17 @@ async def send_refresh_gachalog_msg(bot: Bot, ev: Event):
 
     await bot.send(f"开始刷新{uid}抽卡记录，需要一定时间，请勿重复执行.....")
     im = await save_gachalogs(uid)
+    return await bot.send(im)
+
+
+@sv_get_refresh_gachalog.on_fullmatch(('全量刷新抽卡记录', '全量更新抽卡记录'))
+async def send_full_refresh_gacha_info(bot: Bot, ev: Event):
+    logger.info('开始执行[全量刷新抽卡记录]')
+    uid = await get_uid(bot, ev)
+    if uid is None:
+        return await bot.send(BIND_UID_HINT)
+    await bot.send(
+        f'UID{uid}开始执行[全量刷新抽卡记录],需要一定时间...请勿重复触发！'
+    )
+    im = await get_full_gachalog(uid)
     return await bot.send(im)

--- a/ZZZeroUID/zzzerouid_gachalog/draw_gachalogs.py
+++ b/ZZZeroUID/zzzerouid_gachalog/draw_gachalogs.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Union
 import aiofiles
 from PIL import Image, ImageDraw
 from gsuid_core.models import Event
+from gsuid_core.logger import logger
 from gsuid_core.sv import get_plugin_available_prefix
 from gsuid_core.utils.image.convert import convert_img
 
@@ -244,19 +245,23 @@ async def draw_card(uid: str, ev: Event) -> Union[str, bytes]:
             item_bg.paste(item_mask, (0, 0), item_mask)
 
             item_temp = Image.new('RGBA', (186, 130))
-            if item['item_type'] == '音擎':
-                item_icon = await get_weapon(item['item_id'])
-                item_icon = item_icon.resize((160, 160)).convert('RGBA')
-                item_temp.paste(item_icon, (0, -18), item_icon)
-            elif item['item_type'] == '邦布':
-                item_icon = await get_square_bangboo(item['item_id'])
-                item_icon = item_icon.convert('RGBA')
-                item_temp.paste(item_icon, (32, -19), item_icon)
+            try:
+                if item['item_type'] == '音擎':
+                    item_icon = await get_weapon(item['item_id'])
+                    item_icon = item_icon.resize((160, 160)).convert('RGBA')
+                    item_temp.paste(item_icon, (0, -18), item_icon)
+                elif item['item_type'] == '邦布':
+                    item_icon = await get_square_bangboo(item['item_id'])
+                    item_icon = item_icon.convert('RGBA')
+                    item_temp.paste(item_icon, (32, -19), item_icon)
+                else:
+                    item_icon = await get_square_avatar(item['item_id'])
+                    item_icon.resize((175, 214)).convert('RGBA')
+                    item_temp.paste(item_icon, (10, -24), item_icon)
+            except FileNotFoundError:
+                logger.error(f'{item['item_type']}id:{item['item_id']}图片缺失')
             else:
-                item_icon = await get_square_avatar(item['item_id'])
-                item_icon.resize((175, 214)).convert('RGBA')
-                item_temp.paste(item_icon, (10, -24), item_icon)
-            item_bg.paste(item_temp, (0, 0), item_mask)
+                item_bg.paste(item_temp, (0, 0), item_mask)
 
             item_bg.paste(item_fg, (0, 0), item_fg)
             item_draw = ImageDraw.Draw(item_bg)

--- a/ZZZeroUID/zzzerouid_stamina/notice.py
+++ b/ZZZeroUID/zzzerouid_stamina/notice.py
@@ -27,6 +27,8 @@ async def get_notice_list() -> Dict[str, Dict[str, Dict]]:
                 push_data = await ZzzPush.select_data_by_uid(
                     user.zzz_uid, "zzz"
                 )
+                if push_data is None:
+                    continue
                 msg_dict = await all_check(
                     user.bot_id,
                     raw_data,


### PR DESCRIPTION
体力推送报错见Genshin-bots/gsuid_core#93

因为出现了这种情况
![image](https://github.com/user-attachments/assets/9a2403e0-f2ca-4917-974c-361f5a7c40a9)
于是便把genshinuid那边的全量刷新抽卡记录搬了过来，简单测试了下应该没什么问题

抽卡记录缺失图片就直接日志记录下然后图片留空了
rt
![image](https://github.com/user-attachments/assets/aa8cca11-9eb8-49e7-8fb3-b6ceb1ce1ec4)
顺便genshinuid那边抽卡记录绘图过程中缺失图像也是会直接报错而没有选择类似于如上的处理方式，是出于什么考虑吗
