### PR TITLE
fix: 修复悬赏任务和丽都周纪的完成状态弄反的问题

### DIFF
--- a/ZZZeroUID/zzzerouid_stamina/draw_zzz_stamina.py
+++ b/ZZZeroUID/zzzerouid_stamina/draw_zzz_stamina.py
@@ -208,8 +208,8 @@ async def _draw_stamina_img(uid: str, ev: Event) -> Union[str, Image.Image]:
     active_bar.paste(vitality_icon, (93, 10), vitality_icon)
     gacha_bar.paste(card_icon, (93, 10), card_icon)
     shop_bar.paste(sale_icon, (93, 10), sale_icon)
-    point_bar.paste(bounty_icon, (93, 10), bounty_icon)
-    mission_bar.paste(weekly_icon, (93, 10), weekly_icon)
+    mission_bar.paste(bounty_icon, (93, 10), bounty_icon)
+    point_bar.paste(weekly_icon, (93, 10), weekly_icon)
 
     active_draw.text((716, 56), f"/{max_vitality}", GREY, zzz_font_40, "lm")
     active_draw.text((708, 54), f"{vitality}", YELLOW, zzz_font_50, "rm")


### PR DESCRIPTION
如图：

<img width="950" height="1700" alt="6FE59B6D2EC839ECBA61E6C18733BB1F" src="https://github.com/user-attachments/assets/7dacbc5c-ab45-4c15-99cb-2e50b0a18951" />
