### PR TITLE
🐛 修复私聊/at机器人时 draw_stamina_img 获取 user_id 错误导致 uids 为空

### DIFF
--- a/ZZZeroUID/zzzerouid_stamina/draw_zzz_stamina.py
+++ b/ZZZeroUID/zzzerouid_stamina/draw_zzz_stamina.py
@@ -40,7 +40,7 @@ def convert_seconds_to_hm(seconds: int):
 
 
 async def draw_stamina_img(bot: Bot, ev: Event):
-    user_id = ev.at if ev.at else ev.user_id
+    user_id = ev.at if ev.at and (ev.bot_id != ev.at and ev.bot_self_id != ev.at) else ev.user_id
     uids = await GsBind.get_uid_list_by_game(user_id, ev.bot_id, "zzz")
     if not uids:
         await bot.send(BIND_UID_HINT)


### PR DESCRIPTION
draw_stamina_img 中 user_id 直接取 ev.at，未排除 ev.at 为机器人自身的情况，导致用机器人ID查数据库绑定返回空。 改为与 get_uid() 一致的判断逻辑：排除 ev.at 等于 bot_id 或 bot_self_id 的场景。